### PR TITLE
Add support for USB PID for STLink-V3-SET and STLink-V3-MODS

### DIFF
--- a/gethla.c
+++ b/gethla.c
@@ -47,6 +47,21 @@ static void print_device(libusb_device *dev) {
 							}
 						}
 			break;
+		case 0x374f:
+		case 0x3754:
+			ret = libusb_open(dev, &handle);
+					if (LIBUSB_SUCCESS == ret) {
+						if (desc.iSerialNumber) {
+								ret = libusb_get_string_descriptor_ascii(handle, desc.iSerialNumber, string, sizeof(string));
+								if (ret > 0) {
+									printf("STLink V3   hla_serial ");
+									printf("%s\n",string);
+								} else {
+									printf("Unable to retrieve serial number.\n");
+								}
+							}
+						}
+			break;
 		default:
 			printf("Device not recognised! (%04X)\n", desc.idProduct);
 		}


### PR DESCRIPTION
Super quick change, seems to work fine:

```
Scanning for connected STLink
STLink V3   hla_serial 004000204D4B500D20373831
STLink V2   hla_serial \x57\x3F\x6D\x06\x50\x75\x48\x57\x24\x34\x05\x3F
STLink V3   hla_serial 002D004D3431511937393330
```

Note this probably still doesn't support V3-MINIE and V3-MODS, since their PID may be different.

One possible requested change would be to enumerate the STLink type (V3MODS/V3SET/etc).