### PR TITLE
Change parameter order in Makefile to avoid linker error, when using gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@
 	LDFLAGS   = $(shell pkg-config --libs libusb-1.0)
 
 gethla: gethla.c
-	$(CC) $(INCLUDES) $(LDFLAGS) -o$@ $<
+	$(CC) $< $(INCLUDES) $(LDFLAGS) -o$@ 


### PR DESCRIPTION
Fixes an error: The linker fails if using gcc as default compiler (and not clang). 

Fix: Parameter order was changed.

Tested on Ubuntu 22.04.5 LTS.